### PR TITLE
PR for Reusable Graph Components (Ticket #59)

### DIFF
--- a/driving-day-app-backend/fsae_backend_app/firebase/firebase.py
+++ b/driving-day-app-backend/fsae_backend_app/firebase/firebase.py
@@ -28,11 +28,12 @@ Environment Variables Required:
     - UNIVERSE_DOMAIN
 """
 import firebase_admin
-from firebase_admin import credentials
+from firebase_admin import credentials, auth
 import os
 from dotenv import load_dotenv
 
 load_dotenv()
+
 
 firebase_config = {
     "type": os.getenv("FIREBASE_TYPE"),

--- a/driving-day-app-backend/fsae_backend_app/firebase/firestore.py
+++ b/driving-day-app-backend/fsae_backend_app/firebase/firestore.py
@@ -93,7 +93,7 @@ def get_all_drivers(filters=None):
         print(f"An error occurred while retrieving users: {e}")
         return []
 
-def upload_csv_to_firestore(csv_file_path):
+def upload_csv_to_firestore(csv_file_path, driver_id):
     """
     Uploads data from a CSV file to a Firestore subcollection within a document named after the CSV file.
 
@@ -118,7 +118,8 @@ def upload_csv_to_firestore(csv_file_path):
     main_doc_ref = db.collection(main_collection).document(main_document)
 
     main_doc_ref.set({
-        "run-date": file_name[0:10]
+        "run-date": file_name[0:10],
+        "driver-id": driver_id
     })
 
     subcollection_ref = main_doc_ref.collection(subcollection)

--- a/driving-day-app-backend/fsae_backend_app/ld_parser/main.py
+++ b/driving-day-app-backend/fsae_backend_app/ld_parser/main.py
@@ -11,7 +11,7 @@ from datetime import datetime
 
 db = firestore.client()
 
-def process_and_upload_inputted_ld_file(driver_id, run_date, run_title, data_file):
+def process_and_upload_inputted_ld_file(data_file, run_date, run_title, driver_id):
     '''
         Process LD file that is inputted by the user
     '''
@@ -33,10 +33,10 @@ def process_and_upload_inputted_ld_file(driver_id, run_date, run_title, data_fil
             destination_file.write(file_content)
         
         # await asyncio.to_thread()
-        process_and_upload_ld_files()
+        process_and_upload_ld_files(driver_id)
 
 
-def process_and_upload_ld_files():
+def process_and_upload_ld_files(driver_id):
     '''
         Process LD (Logical Data) files in the data directory, convert them to CSV format, and upload the CSV files to Firestore.
 
@@ -64,7 +64,7 @@ def process_and_upload_ld_files():
                 print(f"Data saved to {csv_filename}")
 
                 # Uploading CSV to Firebase
-                upload_csv_to_firestore(csv_filename)
+                upload_csv_to_firestore(csv_filename, driver_id)
                 print(f"Data from {csv_filename} uploaded to Firestore")
                 
 
@@ -80,5 +80,3 @@ def process_and_upload_ld_files():
     except Exception as e:
         print(e)
 
-if __name__ == '__main__':
-    process_and_upload_ld_files()

--- a/driving-day-app-backend/fsae_backend_app/views.py
+++ b/driving-day-app-backend/fsae_backend_app/views.py
@@ -114,7 +114,7 @@ async def upload_files_call(request):
 
             # Upload to S3
             # Obtain Image URLs:
-            await sync_to_async(process_and_upload_inputted_ld_file)(driver_id, run_date, run_title, data_file)
+            await sync_to_async(process_and_upload_inputted_ld_file)(data_file, run_date, run_title, driver_id)
             return JsonResponse({"message": "Successfully uploaded LD data to database!"}, status=200)
         except Exception as e:
             return JsonResponse({"error": f"An unexpected error occurred: {str(e)}"}, status=500)

--- a/driving-day-app-frontend/src/components/base-component/PageBase.tsx
+++ b/driving-day-app-frontend/src/components/base-component/PageBase.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+
+interface PageBaseProps{
+    children: React.ReactNode;
+}
+
+export default function PageBase({children} : PageBaseProps){
+    return (
+        <div className='page-content-main'>
+            <div className='page-content-body'>
+                {children}
+            </div>
+        </div>
+    )
+}

--- a/driving-day-app-frontend/src/components/contexts/ChartMappingContext.tsx
+++ b/driving-day-app-frontend/src/components/contexts/ChartMappingContext.tsx
@@ -1,0 +1,12 @@
+import { ReusableChartProps } from '../../utils/DataTypes';
+import { createContext } from 'react';
+
+interface ChartMappingContextType {
+    chartMapping: { [key: number]: React.FC<ReusableChartProps> }
+}
+
+const ChartMappingContext = createContext<ChartMappingContextType>(
+    { chartMapping: {} }
+)
+
+export default ChartMappingContext;

--- a/driving-day-app-frontend/src/components/driver-components/DriversList.tsx
+++ b/driving-day-app-frontend/src/components/driver-components/DriversList.tsx
@@ -19,7 +19,7 @@ const DriversList = () => {
   }
 
   return (
-    <div className="w-full bg-white rounded-lg shadow-sm p-8">
+    <>
       <div className="mb-6">
         <h2 className="text-2xl font-semibold">Driver Profiles</h2>
       </div>
@@ -66,7 +66,7 @@ const DriversList = () => {
           </div>
         </div>
       </div>
-    </div>
+    </>
   );
 };
 

--- a/driving-day-app-frontend/src/components/graph-components/LineChartTemplate.tsx
+++ b/driving-day-app-frontend/src/components/graph-components/LineChartTemplate.tsx
@@ -9,11 +9,12 @@ import {
   Title,
   Tooltip,
   Legend,
+  Filler
 } from 'chart.js';
 import { ReusableChartProps } from '../../utils/DataTypes';
 
 // Register necessary components from Chart.js
-ChartJS.register(LineElement, CategoryScale, LinearScale, PointElement, Title, Tooltip, Legend);
+ChartJS.register(LineElement, CategoryScale, LinearScale, PointElement, Title, Tooltip, Legend, Filler);
 
 
 const LineChartTemplate: React.FC<ReusableChartProps> = ({

--- a/driving-day-app-frontend/src/components/graph-components/LineChartTemplate.tsx
+++ b/driving-day-app-frontend/src/components/graph-components/LineChartTemplate.tsx
@@ -70,10 +70,6 @@ const LineChartTemplate: React.FC<ChartDataProps> = ({
         display: true,
         position: 'top' as const,
       },
-      // title: {
-      //   display: true,
-      //   text: `${verticalLabel} Over ${horizontalLabel}`,
-      // },
     },
     scales: {
       x: {
@@ -92,7 +88,11 @@ const LineChartTemplate: React.FC<ChartDataProps> = ({
     },
   };
 
-  return <Line data={data} options={options} />;
+  return (
+    <div className="py-6">
+      <Line data={data} options={options} />
+    </div>
+  )
 };
 
 export default LineChartTemplate;

--- a/driving-day-app-frontend/src/components/graph-components/ScatterChartTemplate.tsx
+++ b/driving-day-app-frontend/src/components/graph-components/ScatterChartTemplate.tsx
@@ -1,23 +1,16 @@
 import React, {useState, useEffect} from 'react';
-import { Line } from 'react-chartjs-2';
+import { Scatter } from 'react-chartjs-2';
 import {
   Chart as ChartJS,
-  LineElement,
-  CategoryScale,
-  LinearScale,
-  PointElement,
-  Title,
-  Tooltip,
-  Legend,
+  registerables
 } from 'chart.js';
 import { ReusableChartProps } from '../../utils/DataTypes';
 
 // Register necessary components from Chart.js
-ChartJS.register(LineElement, CategoryScale, LinearScale, PointElement, Title, Tooltip, Legend);
+ChartJS.register(...registerables);
 
 
-const LineChartTemplate: React.FC<ReusableChartProps> = ({
-    frequency,
+const ScatterChartTemplate: React.FC<ReusableChartProps> = ({
     categoryName,
     verticalLabel,
     horizontalLabel,
@@ -37,7 +30,7 @@ const LineChartTemplate: React.FC<ReusableChartProps> = ({
     const endInd = (sectionNum + 1) * pointsPerSect + 1;
 
     // Generates array of size "pointsPerSect"
-    setTimePoints(Array.from({length: pointsPerSect }, (v, i) => frequency * (i + (startInd + 1))))
+    setTimePoints(Array.from({length: pointsPerSect }, (v, i) => 1 * (i + (startInd + 1))))
     
     // Similar to python [n: m] syntax for array
     setReducedPoints(chartPoints.slice(startInd, endInd).map(kvPair => kvPair[categoryName]))
@@ -45,6 +38,7 @@ const LineChartTemplate: React.FC<ReusableChartProps> = ({
 
 
   // Configuration for the chart data
+  // TODO: Change styling
   const data = {
     labels: timePoints,
     datasets: [
@@ -90,9 +84,10 @@ const LineChartTemplate: React.FC<ReusableChartProps> = ({
 
   return (
     <div className="py-6">
-      <Line data={data} options={options} />
+      {/* <Line data={data} options={options} /> */}
+      <Scatter data={data} options={options}/>
     </div>
   )
 };
 
-export default LineChartTemplate;
+export default ScatterChartTemplate;

--- a/driving-day-app-frontend/src/components/run-components/GeneralRunBubble.tsx
+++ b/driving-day-app-frontend/src/components/run-components/GeneralRunBubble.tsx
@@ -32,7 +32,7 @@ export default function GeneralRunBubble({
             tabIndex={0}
             >
         <div className="flex justify-between items-center mb-4 pb-2 border-b border-gray-100 flex-col">
-            <span className="text-lg font-medium">
+            <span className="text-lg font-bold">
                 <p>{runTitle}</p>
             </span>
             <div className="text-sm text-gray-600">

--- a/driving-day-app-frontend/src/components/run-components/GeneralRunBubble.tsx
+++ b/driving-day-app-frontend/src/components/run-components/GeneralRunBubble.tsx
@@ -1,5 +1,4 @@
 import React, {useState, useEffect} from "react";
-import './RunBubble.css';
 import { Driver } from "../../utils/DriverType";
 
 interface GeneralRunBubbleProps {

--- a/driving-day-app-frontend/src/components/run-components/GeneralRunBubble.tsx
+++ b/driving-day-app-frontend/src/components/run-components/GeneralRunBubble.tsx
@@ -3,24 +3,21 @@ import { Driver } from "../../utils/DriverType";
 
 interface GeneralRunBubbleProps {
   runTitle: string,
-  driver: Driver,
+  runDate: string,
+  driverId: string
   onClick?: () => void;
 }
 
 export default function GeneralRunBubble({
   runTitle,
-  driver,
+  runDate,
+  driverId,
   onClick,
 }: GeneralRunBubbleProps) {
 
-    const [runDate, setRunDate] = useState<string>("2025-01-01");
-    
-    const parseDate = () => {
-        setRunDate(runTitle.substring(0, 10));
-    }
 
     useEffect(() => {
-        parseDate()
+        // TODO: Replace with a fetch call to retrieve driver
     }, [])
 
     return (
@@ -30,23 +27,17 @@ export default function GeneralRunBubble({
             role="button"
             tabIndex={0}
             >
-        <div className="flex justify-between items-center mb-4 pb-2 border-b border-gray-100 flex-col">
+        <div className="flex justify-between mb-4 pb-2 border-b border-gray-100 flex-col">
             <span className="text-lg font-bold">
                 <p>{runTitle}</p>
             </span>
-            <div className="text-sm text-gray-600">
-                <span className="mr-2">Driver: {driver.firstName} {driver.lastName}</span>
+            <div className="text-sm text-gray-600 flex flex-col">
+                <span className="mr-2">Driver: {driverId}</span>
                 <span>Date: {runDate}</span>
             </div>
         </div>
         {/**Replace with description of RUN "Test Coolant " */}
         <div className="flex flex-col">
-            {/* <div
-                className="flex justify-between items-center"
-            >
-                <span className="text-gray-600">Description</span>
-                <span className="font-medium">YAYAYA</span>
-            </div> */}
             <div>
                 <span className="text-gray-600">Desc: </span>
                 <span className="font-medium">Coolant Test</span>

--- a/driving-day-app-frontend/src/components/run-components/LineChartTemplate.tsx
+++ b/driving-day-app-frontend/src/components/run-components/LineChartTemplate.tsx
@@ -1,4 +1,3 @@
-// RunCoolantTemperatureChart.tsx
 import React, {useState, useEffect} from 'react';
 import { Line } from 'react-chartjs-2';
 import {
@@ -12,17 +11,10 @@ import {
   Legend,
 } from 'chart.js';
 import { ChartDataProps } from '../../utils/DataTypes';
-// import './ChartElements.css';
 
 // Register necessary components from Chart.js
 ChartJS.register(LineElement, CategoryScale, LinearScale, PointElement, Title, Tooltip, Legend);
 
-// interface LineChartProps {
-//   timeData: number[]; // Array of time values (e.g., [1, 2, 3, 4, 5])
-//   temperatureData: number[]; // Array of corresponding coolant temperatures
-
-
-// }
 
 const LineChartTemplate: React.FC<ChartDataProps> = ({
     frequency,
@@ -32,7 +24,7 @@ const LineChartTemplate: React.FC<ChartDataProps> = ({
     chartPoints,
 }) => {
 
-  // Create array of first 20 points (similar to pagination), mulitplied by frequency
+  // Create array of first 20 points (similar to pagination)
   const [reducedPoints, setReducedPoints] = useState<number[]>()
   const [timePoints, setTimePoints] = useState<number[]>()
 

--- a/driving-day-app-frontend/src/components/run-components/RunBubble.css
+++ b/driving-day-app-frontend/src/components/run-components/RunBubble.css
@@ -1,5 +1,0 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
-
-@layer components {}

--- a/driving-day-app-frontend/src/components/run-components/SpecificRunBubble.tsx
+++ b/driving-day-app-frontend/src/components/run-components/SpecificRunBubble.tsx
@@ -1,11 +1,6 @@
 import React, {useState, useEffect} from "react";
-import './RunBubble.css';
 import { Driver } from "../../utils/DriverType";
 
-// interface Metric {
-//   label: string;
-//   value: string;
-// }
 
 interface SpecificRunBubbleProps {
   runTitle: string,
@@ -34,7 +29,7 @@ export default function SpecificRunBubble({
 
   return (
     <div
-      className="font-face bg-white rounded-lg border border-gray-200 p-4 cursor-pointer transition-colors hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-2"
+      className="font-face bg-white rounded-lg border border-gray-200 p-4 focus:outline-none"
       role="button"
       tabIndex={0}
     >

--- a/driving-day-app-frontend/src/components/run-components/SpecificRunBubble.tsx
+++ b/driving-day-app-frontend/src/components/run-components/SpecificRunBubble.tsx
@@ -4,27 +4,24 @@ import { Driver } from "../../utils/DriverType";
 
 interface SpecificRunBubbleProps {
   runTitle: string,
-  // Implicily a JSON type
+  runDate: string,
+  driverId: string
+    // Implicily a JSON type
   keyPoints: any,
   keyCategories: string[],
-  driver: Driver,
 }
 
 export default function SpecificRunBubble({
   runTitle,
+  runDate,
+  driverId,
   keyPoints,
   keyCategories,
-  driver,
 }: SpecificRunBubbleProps) {
 
-    const [runDate, setRunDate] = useState<string>("2025-01-01");
-
-    const parseDate = () => {
-        setRunDate(runTitle.substring(0, 10));
-    }
 
     useEffect(() => {
-        parseDate()
+        // TODO: Pull driver
     }, [])
 
   return (
@@ -38,7 +35,7 @@ export default function SpecificRunBubble({
           <p>Title: {runTitle}</p>
         </span>
         <div className="text-sm text-gray-600">
-          <span className="mr-2">Driver: {driver.firstName} {driver.lastName}</span>
+          <span className="mr-2">Driver: {driverId}</span>
           <span>Date: {runDate}</span>
         </div>
       </div>

--- a/driving-day-app-frontend/src/components/upload-components/UploadComponent.css
+++ b/driving-day-app-frontend/src/components/upload-components/UploadComponent.css
@@ -12,13 +12,8 @@
 }
 
 
-.driver-option {
-    color: #24a0ed;
-}
-
 .disabled-upload-button,
 .upload-button {
-    background-color: #24a0ed;
     color: white;
     padding: 0.5rem 1rem;
     border-radius: 0.5rem;
@@ -26,6 +21,5 @@
 }
 
 .upload-button:hover {
-    animation: fadeIn 0.5s;
     opacity: 0.75;
 }

--- a/driving-day-app-frontend/src/components/upload-components/UploadComponent.tsx
+++ b/driving-day-app-frontend/src/components/upload-components/UploadComponent.tsx
@@ -111,7 +111,6 @@ export default function UploadComponent() {
                     <div className="upload-metadata flex flex-col items-center w-full">
                         <input
                             value={runTitle}
-                            className="focus:outline-none focus:ring-2 focus:ring-blue-600 focus:border-transparent"
                             placeholder='Enter run title...'
                             onKeyDown={(event) => {
                                 if (event.key === " ") {
@@ -127,21 +126,17 @@ export default function UploadComponent() {
                             selected={runDate}
                             onChange={(date) => setRunDate(date)}
                         />
-                        <select className="focus:outline-none focus:ring-2 focus:ring-blue-600 focus:border-transparent" onChange={(event) => setDriverId(event.target.value)}>
-                                <option value="">
-                                    Select Driver
-                                </option>
-
-                                {drivers && drivers.map(currentDriver => {
-                                    return (
-                                        <option
-                                            value={currentDriver.driverId}
-                                            className="driver-option"
-                                            key={currentDriver.driverId}>
-                                            {currentDriver.firstName} {currentDriver.lastName}
-                                        </option>
-                                    )
-                                })}
+                        <select onChange={(event) => setDriverId(event.target.value)}>
+                            {drivers && drivers.map(currentDriver => {
+                                return (
+                                    <option
+                                        value={currentDriver.driverId}
+                                        className="driver-option"
+                                        key={currentDriver.driverId}>
+                                        {currentDriver.firstName} {currentDriver.lastName}
+                                    </option>
+                                )
+                            })}
                         </select>
                     </div>
                 </div>
@@ -149,10 +144,10 @@ export default function UploadComponent() {
 
                 <div className="flex justify-center py-10">
                     {uploading
-                        ? <button disabled={true} className="disabled-upload-button opacity-70">
+                        ? <button disabled={true} className="disabled-upload-button opacity-70 bg-blue-600">
                             <p>Uploading...</p>
                         </button>
-                        : <button onClick={submitUpload} className="upload-button">
+                        : <button onClick={submitUpload} className="upload-button bg-blue-500">
                             <p>Upload Data</p>
                         </button>
                     }

--- a/driving-day-app-frontend/src/components/upload-components/UploadComponent.tsx
+++ b/driving-day-app-frontend/src/components/upload-components/UploadComponent.tsx
@@ -80,7 +80,7 @@ export default function UploadComponent() {
             <div className="flex justify-center flex-col items-center">
                 <div className="grid grid-cols-2 w-full justify-center items-center">
                     <div className="flex flex-col justify-center items-center">
-                        <div className="w-10/12 py-4 justify-center">
+                        <div className="w-11/12 py-4 justify-center">
                             <div className="text-center p-2">
                                 <p>Upload CSV or LD File</p>
                             </div>
@@ -92,7 +92,7 @@ export default function UploadComponent() {
                                 server={null} />
                         </div>
 
-                        <div className="w-10/12 py-4 justify-center">
+                        <div className="w-11/12 py-4 justify-center">
                             <div className="text-center p-2">
                                 <p>Upload Media Files</p>
                             </div>
@@ -109,29 +109,25 @@ export default function UploadComponent() {
                     </div>
 
                     <div className="upload-metadata flex flex-col items-center w-full">
-
-                        <p>
-                            <input
-                                value={runTitle}
-                                className="focus:outline-none focus:ring-2 focus:ring-blue-600 focus:border-transparent"
-                                placeholder='Enter run title...'
-                                onKeyDown={(event) => {
-                                    if (event.key === " ") {
-                                        event.preventDefault()
-                                        setRunTitle(runTitle + "-")
-                                    }
-                                }}
-                                onChange={(event) => setRunTitle(event.target.value.toLocaleLowerCase())}>
-                            </input>
-                        </p>
+                        <input
+                            value={runTitle}
+                            className="focus:outline-none focus:ring-2 focus:ring-blue-600 focus:border-transparent"
+                            placeholder='Enter run title...'
+                            onKeyDown={(event) => {
+                                if (event.key === " ") {
+                                    event.preventDefault()
+                                    setRunTitle(runTitle + "-")
+                                }
+                            }}
+                            onChange={(event) => setRunTitle(event.target.value.toLocaleLowerCase())}>
+                        </input>
 
                         <DatePicker
                             className="focus:outline-none focus:ring-2 focus:ring-blue-600 focus:border-transparent"
                             selected={runDate}
                             onChange={(date) => setRunDate(date)}
                         />
-                        <p>
-                            <select className="focus:outline-none focus:ring-2 focus:ring-blue-600 focus:border-transparent" onChange={(event) => setDriverId(event.target.value)}>
+                        <select className="focus:outline-none focus:ring-2 focus:ring-blue-600 focus:border-transparent" onChange={(event) => setDriverId(event.target.value)}>
                                 <option value="">
                                     Select Driver
                                 </option>
@@ -146,8 +142,7 @@ export default function UploadComponent() {
                                         </option>
                                     )
                                 })}
-                            </select>
-                        </p>
+                        </select>
                     </div>
                 </div>
 

--- a/driving-day-app-frontend/src/index.css
+++ b/driving-day-app-frontend/src/index.css
@@ -5,9 +5,10 @@
 
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
+  /* font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
     'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
+    sans-serif; */
+  font-family: "Geist Mono", monospace;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }

--- a/driving-day-app-frontend/src/pages/drivers-page/DriversPage.tsx
+++ b/driving-day-app-frontend/src/pages/drivers-page/DriversPage.tsx
@@ -1,13 +1,14 @@
 import React from "react";
 import DriversList from "../../components/driver-components/DriversList";
+import PageBase from "../../components/base-component/PageBase";
 
 export default function DriversPage() {
 
     // TODO: Move entire DriversList code here
     // Modularize DriversList.tsx into multiple components
     return (
-        <div className="page-content-main">
+        <PageBase>
             <DriversList />
-        </div>
+        </PageBase>
     )
 }

--- a/driving-day-app-frontend/src/pages/home-page/Home.tsx
+++ b/driving-day-app-frontend/src/pages/home-page/Home.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
+import PageBase from '../../components/base-component/PageBase';
 
 const Home: React.FC = () => {
 
     return (
-        <div>
+        <PageBase>
             <h1>Home</h1>
             <p>Check the console to see the first three data items.</p>
-        </div>
+        </PageBase>
     );
 };
 

--- a/driving-day-app-frontend/src/pages/issues-page/Issues.tsx
+++ b/driving-day-app-frontend/src/pages/issues-page/Issues.tsx
@@ -1,16 +1,13 @@
 import React from "react";
 import IssueTable from "../../components/issues-components/IssuesTable";
+import PageBase from "../../components/base-component/PageBase";
 
 const Issues: React.FC = () => {
   return (
-    <div className="page-content-main">
-      <div className="w-full p-8">
-        <div>
-          <h1 className="mb-6 text-2xl font-semibold">Issues</h1>
-          <IssueTable />
-        </div>
-      </div>
-    </div>
+    <PageBase>
+        <h1 className="mb-6 text-2xl font-semibold">Issues</h1>
+        <IssueTable />
+    </PageBase>
   );
 };
 

--- a/driving-day-app-frontend/src/pages/layout/Layout.css
+++ b/driving-day-app-frontend/src/pages/layout/Layout.css
@@ -33,4 +33,8 @@
         font-size: 48px; */
         @apply mb-6 text-2xl font-semibold;
     }
+
+    select, input{
+        @apply focus:outline-none focus:ring-2 focus:ring-blue-600 focus:border-transparent;
+    }
 }

--- a/driving-day-app-frontend/src/pages/layout/Layout.css
+++ b/driving-day-app-frontend/src/pages/layout/Layout.css
@@ -1,6 +1,6 @@
 @tailwind base;
 @tailwind components;
-@tailwind utilies;
+@tailwind utilities;
 
 @keyframes fadeIn {
     0% {
@@ -24,18 +24,13 @@
         margin-left: 16rem;
     }
 
-    p {
-        font-family: "Geist Mono", monospace;
-        font-size: 16px;
-    }
-
-    a {
-        font-family: "Geist Mono", monospace;
-        font-size: 16px;
+    .page-content-body{
+        @apply w-full p-8 max-w-7xl mx-auto;
     }
 
     h1 {
-        font-family: "Geist Mono", monospace;
-        font-size: 48px;
+        /* font-family: "Geist Mono", monospace;
+        font-size: 48px; */
+        @apply mb-6 text-2xl font-semibold;
     }
 }

--- a/driving-day-app-frontend/src/pages/layout/Layout.tsx
+++ b/driving-day-app-frontend/src/pages/layout/Layout.tsx
@@ -1,10 +1,19 @@
 import { Outlet } from "react-router-dom";
 import Navbar from "../../components/navbar-components/Navbar";
 import './Layout.css';
-import { createContext, useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 import { Driver } from "../../utils/DriverType";
 import { getAllDrivers } from "../../api/api";
 import AppDataContext from "../../components/contexts/AppDataContext";
+import ChartMappingContext from "../../components/contexts/ChartMappingContext";
+import LineChartTemplate from '../../components/graph-components/LineChartTemplate';
+import ScatterChartTemplate from '../../components/graph-components/ScatterChartTemplate';
+import { ReusableChartProps } from "../../utils/DataTypes";
+
+const chartMapping : { [key: number]: React.FC<ReusableChartProps> } = {
+    0 : LineChartTemplate,
+    1 : ScatterChartTemplate
+}
 
 export default function Layout() {
 
@@ -24,13 +33,18 @@ export default function Layout() {
 
     return (
         <div className="wrapper">
-            <AppDataContext.Provider value={{
-                drivers: drivers,
-                isLoading: isLoading
+            <ChartMappingContext.Provider value={{
+                chartMapping: chartMapping
             }}>
-                <Navbar />
-                <Outlet />
-            </AppDataContext.Provider>
+                <AppDataContext.Provider value={{
+                    drivers: drivers,
+                    isLoading: isLoading
+                }}>
+                    <Navbar />
+                    <Outlet />
+                </AppDataContext.Provider>
+            </ChartMappingContext.Provider>
+            
         </div>
 
     )

--- a/driving-day-app-frontend/src/pages/run-page/ChartElements.css
+++ b/driving-day-app-frontend/src/pages/run-page/ChartElements.css
@@ -6,4 +6,10 @@
   .run-detail-chart canvas {
     width: 100% !important;
   }
+
+  .graph-heading{
+    font-weight: 600;
+    font-size: 1.5rem;
+    padding: 1rem 0;
+  }
 }

--- a/driving-day-app-frontend/src/pages/run-page/RunDetail.tsx
+++ b/driving-day-app-frontend/src/pages/run-page/RunDetail.tsx
@@ -1,23 +1,22 @@
-import React, {useState, useEffect} from 'react'
+import React, {useState, useEffect, useContext} from 'react'
+import ChartMappingContext from '../../components/contexts/ChartMappingContext';
 import { useParams, useLocation } from 'react-router-dom';
 import SpecificRunBubble from '../../components/run-components/SpecificRunBubble';
-import LineChartTemplate from '../../components/graph-components/LineChartTemplate';
-import ScatterChartTemplate from '../../components/graph-components/ScatterChartTemplate';
 import PageBase from '../../components/base-component/PageBase';
 import './ChartElements.css';
 import { getSpecificRunData } from '../../api/api';
-import { CATEGORIES, ReusableChartProps } from '../../utils/DataTypes';
-
+import { CATEGORIES, DataCategory, ReusableChartProps } from '../../utils/DataTypes';
+import { CHARTS, ChartCategory } from '../../utils/ChartTypes';
 
 const RunDetailRevised: React.FC = () => {
     
+    const { chartMapping } = useContext(ChartMappingContext)
     const {runTitle} = useParams()
     const location = useLocation()
 
     const [isLoading, setLoading] = useState<boolean>(true);
     const [runDate, setRunDate] = useState<string>("")
     const [driverId, setDriverId] = useState<string>("")
-
     
     // Adapt this into DataTypes.ts
     const keyCategories = ["Highest Coolant Temperature"]
@@ -36,13 +35,9 @@ const RunDetailRevised: React.FC = () => {
     /**
      * useState variables for chart-data
      */
-    const [chartData, setChartData] = useState<ReusableChartProps>({
-        frequency: 1,
-        categoryName: "",
-        verticalLabel: "Metric Y",
-        horizontalLabel: "Metrix X (E.X. Time)",
-        chartPoints: [],
-    })
+    const chartCategories : ChartCategory[] = Object.values(CHARTS)
+    const [currChartInd, setCurrChartInd] = useState<number>(0)
+    const CurrentChart : React.FC<ReusableChartProps> = chartMapping[currChartInd]
 
     /**
      * Perform fetch call to pull specific run data
@@ -64,24 +59,7 @@ const RunDetailRevised: React.FC = () => {
         }
     }
 
-    const updateChartData = async () => {
-        // TODO: Update to whatever the user toggles
-        setChartData({
-            frequency: 1,
-            categoryName: CATEGORIES.ENG_OIL_PRESSURE,
-            verticalLabel: verticalLabel,
-            horizontalLabel: horizontalLabel,
-            chartPoints: runDataPoints
-        })
-
-        console.log("UPATED???")
-    }
-
-    // TODO: Create fetch API call to obtain current driver based on ID
     // TODO: Create fetch API call to obtain run meta-data by runTitle (called when necessary)
-
-
-
     
     useEffect(() => {
         // USE localStorage to cache in the future
@@ -98,9 +76,7 @@ const RunDetailRevised: React.FC = () => {
         }
 
         fetchSpecificRunData()
-        updateChartData()        
     }, [])
-
 
     if (isLoading) {
         return (
@@ -131,40 +107,45 @@ const RunDetailRevised: React.FC = () => {
 
                 <div className="pt-16">
                     <h1>Graphs</h1>
-                    <div className="flex">
-                        {/**
-                         * TODO: Load in ALL unique columns for this
-                         * 
-                         * 
-                         */}
-                        <select className="text-lg px-4 py-2 border border-gray-200 rounded-md text-blue-800 font-semibold text-1xl"
-                            onChange={(event) => setVerticalLabel(event.target.value)}
-                        >
-                            <option value={CATEGORIES.ENG_OIL_PRESSURE}>
-                                <section>{CATEGORIES.ENG_OIL_PRESSURE}</section>
-                            </option>
-                        </select>
+                    <div className='flex flex-col'>
+                        <div className="flex py-2">
+                            <section className='px-4 py-2'>Columns</section>
 
-                        <section className="px-4 py-2">
-                            vs 
-                        </section>
-                        <select className="text-lg px-4 py-2 border border-gray-200 rounded-md text-red-800 font-semibold text-1xl"
-                            // onChange={(event) => setHorizontalLabel(event.target.value)}
-                        >
-                            <option value="">
-                                <section>{"Time"}</section>
-                            </option>
-                        </select>
-                    </div>
-                    <LineChartTemplate 
+                            <select className="text-lg px-4 py-2 border border-gray-200 rounded-md text-blue-800 font-semibold text-1xl"
+                                onChange={(event) => setVerticalLabel(event.target.value)}
+                            >
+                                <option value={CATEGORIES.ENG_OIL_PRESSURE}> {CATEGORIES.ENG_OIL_PRESSURE} </option>
+                            </select>
+
+                            <section className="px-4 py-2"> vs </section>
+                            <select className="text-lg px-4 py-2 border border-gray-200 rounded-md text-red-800 font-semibold text-1xl"
+                                // onChange={(event) => setHorizontalLabel(event.target.value)}
+                            >
+                                <option value=""> {"Time"} </option>
+                            </select>
+                        </div>
+                        <div className='flex py-2'>
+                            <section className='px-4 py-2'>Chart Type</section>
+                            <select className="text-lg px-4 py-2 border border-gray-200 rounded-md text-purple-800 font-semibold text-1xl"
+                                onChange={(event) => setCurrChartInd(Number(event.target.value))}
+                            >
+                                {chartCategories.map((category, index) => {
+                                    return (
+                                        <option key={index} value={index}> {category} </option>
+                                    )
+                                })}
+                            </select>
+                        </div>
+                    </div>           
+
+                    <CurrentChart 
                         frequency={1}
-                        categoryName={CATEGORIES.ENG_OIL_PRESSURE}
+                        categoryName={verticalLabel}
                         verticalLabel={verticalLabel}
                         horizontalLabel={horizontalLabel}
                         chartPoints={runDataPoints}
-                    />
-                        {/* {...props} : Method of passing in props as an object*/}
-                        {/* <ScatterChartTemplate {...chartData}/> */}
+                    />      
+                    {/* {...props} : Method of passing in props as an object*/}
                 </div>
             </div>
         </PageBase>

--- a/driving-day-app-frontend/src/pages/run-page/RunDetail.tsx
+++ b/driving-day-app-frontend/src/pages/run-page/RunDetail.tsx
@@ -1,30 +1,29 @@
 import React, {useState, useEffect} from 'react'
-import { useParams } from 'react-router-dom';
+import { useParams, useLocation } from 'react-router-dom';
 import SpecificRunBubble from '../../components/run-components/SpecificRunBubble';
 import LineChartTemplate from '../../components/graph-components/LineChartTemplate';
+import ScatterChartTemplate from '../../components/graph-components/ScatterChartTemplate';
 import PageBase from '../../components/base-component/PageBase';
 import './ChartElements.css';
 import { getSpecificRunData } from '../../api/api';
-import { CATEGORIES } from '../../utils/DataTypes';
-import { Driver } from '../../utils/DriverType';
+import { CATEGORIES, ReusableChartProps } from '../../utils/DataTypes';
 
 
 const RunDetailRevised: React.FC = () => {
     
     const {runTitle} = useParams()
-
-    // Adapt this into DataTypes.ts
-    const keyCategories = ["Highest Coolant Temperature"]
+    const location = useLocation()
 
     const [isLoading, setLoading] = useState<boolean>(true);
-    const [driver, setDriver] = useState<Driver>({
-        driverId: 'UNDEF',
-        firstName: 'UNDEF',
-        lastName: 'UNDEF',
-        height: -1,
-        weight: -1,
-        pedalBoxPos: -1
-    })
+    const [runDate, setRunDate] = useState<string>("")
+    const [driverId, setDriverId] = useState<string>("")
+
+    
+    // Adapt this into DataTypes.ts
+    const keyCategories = ["Highest Coolant Temperature"]
+    /**
+     * useState variables for run-data
+     */
     // Array of JSON entries
     const [runDataPoints, setRunDataPoints] = useState<any[]>([])
     // JSON entries of most important points
@@ -34,7 +33,14 @@ const RunDetailRevised: React.FC = () => {
     const [verticalLabel, setVerticalLabel] = useState<string>(CATEGORIES.ENG_OIL_PRESSURE)
     const [horizontalLabel, setHorizontalLabel] = useState<string>("Time")
     
+    /**
+     * useState variables for chart-data
+     */
+    const [chartData, setChartData] = useState<ReusableChartProps>()
 
+    /**
+     * Perform fetch call to pull specific run data
+     */
     const fetchSpecificRunData = async () => {
         const response = await getSpecificRunData({
             runTitle: runTitle || "sample_data",
@@ -54,6 +60,10 @@ const RunDetailRevised: React.FC = () => {
         // Update driver too
     }
 
+    // TODO: Create fetch API call to obtain run meta-data by runTitle
+
+
+
     
     useEffect(() => {
         // USE localStorage to cache in the future
@@ -65,6 +75,11 @@ const RunDetailRevised: React.FC = () => {
          *      value: JSON.stringify(<content>)
          */
         fetchSpecificRunData()
+
+        if(location.state){
+            setRunDate(location.state['run-date'])
+            setDriverId(location.state['driver-id'])
+        }
     }, [])
 
 
@@ -86,9 +101,10 @@ const RunDetailRevised: React.FC = () => {
                 {runTitle ? (
                     <SpecificRunBubble
                         runTitle={runTitle}
+                        runDate={runDate}
+                        driverId={driverId}
                         keyPoints={keyPoints}
                         keyCategories={keyCategories}
-                        driver={driver}
                         />
                 ) : (
                     <p className="text-lg text-gray-600">Run details not found.</p>
@@ -121,13 +137,19 @@ const RunDetailRevised: React.FC = () => {
                             </option>
                         </select>
                     </div>
-                    <LineChartTemplate 
+                    {/* <LineChartTemplate 
                         frequency={1}
                         categoryName={CATEGORIES.ENG_OIL_PRESSURE}
                         verticalLabel={verticalLabel}
                         horizontalLabel={horizontalLabel}
                         chartPoints={runDataPoints}
-                    />
+                    /> */}
+                        <ScatterChartTemplate
+                            frequency={1}
+                            categoryName={CATEGORIES.ENG_OIL_PRESSURE}
+                            verticalLabel={verticalLabel}
+                            horizontalLabel={horizontalLabel}
+                            chartPoints={runDataPoints}/>
                 </div>
             </div>
         </PageBase>

--- a/driving-day-app-frontend/src/pages/run-page/RunDetail.tsx
+++ b/driving-day-app-frontend/src/pages/run-page/RunDetail.tsx
@@ -36,7 +36,13 @@ const RunDetailRevised: React.FC = () => {
     /**
      * useState variables for chart-data
      */
-    const [chartData, setChartData] = useState<ReusableChartProps>()
+    const [chartData, setChartData] = useState<ReusableChartProps>({
+        frequency: 1,
+        categoryName: "",
+        verticalLabel: "Metric Y",
+        horizontalLabel: "Metrix X (E.X. Time)",
+        chartPoints: [],
+    })
 
     /**
      * Perform fetch call to pull specific run data
@@ -56,11 +62,21 @@ const RunDetailRevised: React.FC = () => {
             setKeyPoints(response.data.keyPoints)
             setLoading(false)
         }
-
-        // Update driver too
     }
 
-    // TODO: Create fetch API call to obtain run meta-data by runTitle
+    const updateChartData = async () => {
+        // TODO: Update to whatever the user toggles
+        setChartData({
+            frequency: 1,
+            categoryName: CATEGORIES.ENG_OIL_PRESSURE,
+            verticalLabel: verticalLabel,
+            horizontalLabel: horizontalLabel,
+            chartPoints: runDataPoints
+        })
+    }
+
+    // TODO: Create fetch API call to obtain current driver based on ID
+    // TODO: Create fetch API call to obtain run meta-data by runTitle (called when necessary)
 
 
 
@@ -74,12 +90,13 @@ const RunDetailRevised: React.FC = () => {
          *      expiry: <1 Week date time>
          *      value: JSON.stringify(<content>)
          */
-        fetchSpecificRunData()
-
         if(location.state){
             setRunDate(location.state['run-date'])
             setDriverId(location.state['driver-id'])
         }
+
+        fetchSpecificRunData()
+        updateChartData()        
     }, [])
 
 
@@ -144,12 +161,8 @@ const RunDetailRevised: React.FC = () => {
                         horizontalLabel={horizontalLabel}
                         chartPoints={runDataPoints}
                     /> */}
-                        <ScatterChartTemplate
-                            frequency={1}
-                            categoryName={CATEGORIES.ENG_OIL_PRESSURE}
-                            verticalLabel={verticalLabel}
-                            horizontalLabel={horizontalLabel}
-                            chartPoints={runDataPoints}/>
+                        {/* {...props} : Method of passing in props as an object*/}
+                        <ScatterChartTemplate {...chartData}/>
                 </div>
             </div>
         </PageBase>

--- a/driving-day-app-frontend/src/pages/run-page/RunDetail.tsx
+++ b/driving-day-app-frontend/src/pages/run-page/RunDetail.tsx
@@ -2,6 +2,7 @@ import React, {useState, useEffect} from 'react'
 import { useNavigate, useParams } from 'react-router-dom';
 import SpecificRunBubble from '../../components/run-components/SpecificRunBubble';
 import LineChartTemplate from '../../components/run-components/LineChartTemplate';
+import PageBase from '../../components/base-component/PageBase';
 import './ChartElements.css';
 import { getSpecificRunData } from '../../api/api';
 import { CATEGORIES } from '../../utils/DataTypes';
@@ -67,20 +68,18 @@ const RunDetailRevised: React.FC = () => {
 
     if (isLoading) {
         return (
-            <div className='page-content-main'>
+            <PageBase>
                 <div className="flex items-center justify-center h-64">
                     Loading run data...
                 </div>
-            </div>    
+            </PageBase>    
         );
     }
 
     return (
-        <div className="page-content-main">
-
-        <div className="w-full p-8">
+        <PageBase>
             <div className="run-detail-chart">
-                <h1 className="mb-6 text-2xl font-semibold">{`"${runTitle}" Details`}</h1>
+                <h1>{`"${runTitle}" Details`}</h1>
 
                 {runTitle ? (
                     <SpecificRunBubble
@@ -94,6 +93,7 @@ const RunDetailRevised: React.FC = () => {
                 )}
 
                 <div className="py-8">
+                    {/* <h2 className="text-2xl font-semibold py-4">Graphs</h2> */}
                     <LineChartTemplate 
                         frequency={1}
                         categoryName={CATEGORIES.ENG_OIL_PRESSURE}
@@ -102,10 +102,8 @@ const RunDetailRevised: React.FC = () => {
                         chartPoints={runDataPoints}
                     />
                 </div>
-                
-                </div>
             </div>
-        </div>
+        </PageBase>
     );
 
 };

--- a/driving-day-app-frontend/src/pages/run-page/RunDetail.tsx
+++ b/driving-day-app-frontend/src/pages/run-page/RunDetail.tsx
@@ -73,6 +73,8 @@ const RunDetailRevised: React.FC = () => {
             horizontalLabel: horizontalLabel,
             chartPoints: runDataPoints
         })
+
+        console.log("UPATED???")
     }
 
     // TODO: Create fetch API call to obtain current driver based on ID
@@ -154,15 +156,15 @@ const RunDetailRevised: React.FC = () => {
                             </option>
                         </select>
                     </div>
-                    {/* <LineChartTemplate 
+                    <LineChartTemplate 
                         frequency={1}
                         categoryName={CATEGORIES.ENG_OIL_PRESSURE}
                         verticalLabel={verticalLabel}
                         horizontalLabel={horizontalLabel}
                         chartPoints={runDataPoints}
-                    /> */}
+                    />
                         {/* {...props} : Method of passing in props as an object*/}
-                        <ScatterChartTemplate {...chartData}/>
+                        {/* <ScatterChartTemplate {...chartData}/> */}
                 </div>
             </div>
         </PageBase>

--- a/driving-day-app-frontend/src/pages/run-page/RunDetail.tsx
+++ b/driving-day-app-frontend/src/pages/run-page/RunDetail.tsx
@@ -1,7 +1,7 @@
 import React, {useState, useEffect} from 'react'
-import { useNavigate, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import SpecificRunBubble from '../../components/run-components/SpecificRunBubble';
-import LineChartTemplate from '../../components/run-components/LineChartTemplate';
+import LineChartTemplate from '../../components/graph-components/LineChartTemplate';
 import PageBase from '../../components/base-component/PageBase';
 import './ChartElements.css';
 import { getSpecificRunData } from '../../api/api';
@@ -12,8 +12,6 @@ import { Driver } from '../../utils/DriverType';
 const RunDetailRevised: React.FC = () => {
     
     const {runTitle} = useParams()
-    const navigate = useNavigate()
-
 
     // Adapt this into DataTypes.ts
     const keyCategories = ["Highest Coolant Temperature"]
@@ -31,6 +29,10 @@ const RunDetailRevised: React.FC = () => {
     const [runDataPoints, setRunDataPoints] = useState<any[]>([])
     // JSON entries of most important points
     const [keyPoints, setKeyPoints] = useState<JSON>(JSON.parse("{}"))
+
+    // States to store the currently-toggled column
+    const [verticalLabel, setVerticalLabel] = useState<string>(CATEGORIES.ENG_OIL_PRESSURE)
+    const [horizontalLabel, setHorizontalLabel] = useState<string>("Time")
     
 
     const fetchSpecificRunData = async () => {
@@ -92,13 +94,38 @@ const RunDetailRevised: React.FC = () => {
                     <p className="text-lg text-gray-600">Run details not found.</p>
                 )}
 
-                <div className="py-8">
-                    {/* <h2 className="text-2xl font-semibold py-4">Graphs</h2> */}
+                <div className="pt-16">
+                    <h1>Graphs</h1>
+                    <div className="flex">
+                        {/**
+                         * TODO: Load in ALL unique columns for this
+                         * 
+                         * 
+                         */}
+                        <select className="text-lg px-4 py-2 border border-gray-200 rounded-md text-blue-800 font-semibold text-1xl"
+                            onChange={(event) => setVerticalLabel(event.target.value)}
+                        >
+                            <option value={CATEGORIES.ENG_OIL_PRESSURE}>
+                                <section>{CATEGORIES.ENG_OIL_PRESSURE}</section>
+                            </option>
+                        </select>
+
+                        <section className="px-4 py-2">
+                            vs 
+                        </section>
+                        <select className="text-lg px-4 py-2 border border-gray-200 rounded-md text-red-800 font-semibold text-1xl"
+                            // onChange={(event) => setHorizontalLabel(event.target.value)}
+                        >
+                            <option value="">
+                                <section>{"Time"}</section>
+                            </option>
+                        </select>
+                    </div>
                     <LineChartTemplate 
                         frequency={1}
                         categoryName={CATEGORIES.ENG_OIL_PRESSURE}
-                        verticalLabel={"Engine Oil Pressure (kPa)"}
-                        horizontalLabel={"Time (s)"}
+                        verticalLabel={verticalLabel}
+                        horizontalLabel={horizontalLabel}
                         chartPoints={runDataPoints}
                     />
                 </div>

--- a/driving-day-app-frontend/src/pages/run-summary/RunSummary.tsx
+++ b/driving-day-app-frontend/src/pages/run-summary/RunSummary.tsx
@@ -3,25 +3,22 @@ import GeneralRunBubble from "../../components/run-components/GeneralRunBubble";
 import PageBase from "../../components/base-component/PageBase";
 import { useNavigate } from "react-router-dom";
 import { getGeneralRunData } from "../../api/api";
-import { Driver } from "../../utils/DriverType";
 
 const RunsSummaryPage: React.FC = () => {
 
   const navigate = useNavigate();
-  const templateDriver : Driver = {
-    driverId: 'UNDEF',
-    firstName: 'UNDEF',
-    lastName: 'UNDEF',
-    height: -1,
-    weight: -1,
-    pedalBoxPos: -1
-  }
+  
   const [isLoading, setLoading] = useState<boolean>(true);
   // JSON array of general run data
   const [generalRuns, setGeneralRuns] = useState<any[]>([])
   
-  const handleRunClick = (runTitle: string) => {
-    navigate(`/runs/${runTitle}`);
+  const handleRunClick = (runTitle: string, runDate: string, driverId: string) => {
+    navigate(`/runs/${runTitle}`, {
+      state: {
+        "run-date": runDate,
+        "driver-id": driverId
+      }
+    });
   };
 
   const fetchGeneralRunData = async () => {
@@ -59,12 +56,15 @@ const RunsSummaryPage: React.FC = () => {
         </div>
 
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 auto-rows-min">
-          {generalRuns.map((generalRun) => (
+          {generalRuns.map((generalRun, index) => (
             <GeneralRunBubble
-              key={generalRun.id}
-              runTitle={generalRun.id}
-              driver={templateDriver}
-              onClick={() => handleRunClick(generalRun.id)}
+              key={index}
+              runTitle={generalRun['id']}
+              runDate={generalRun['run-date']}
+              driverId={generalRun['driver-id']}
+              onClick={() => 
+                handleRunClick(generalRun['id'], generalRun['run-date'], generalRun['driver-id'])
+              }
             />
           ))}
         </div>

--- a/driving-day-app-frontend/src/pages/run-summary/RunSummary.tsx
+++ b/driving-day-app-frontend/src/pages/run-summary/RunSummary.tsx
@@ -1,6 +1,6 @@
 import React, {useState, useEffect} from "react";
-// import RunBubble from "../../components/run-components/RunBubble";
 import GeneralRunBubble from "../../components/run-components/GeneralRunBubble";
+import PageBase from "../../components/base-component/PageBase";
 import { useNavigate } from "react-router-dom";
 import { getGeneralRunData } from "../../api/api";
 import { Driver } from "../../utils/DriverType";
@@ -40,39 +40,35 @@ const RunsSummaryPage: React.FC = () => {
   }, [])
 
   return (
-    <div className="page-content-main">
-      <div className="w-full">
-        <div className="p-8 max-w-7xl mx-auto">
-          <h1 className="mb-6 text-2xl font-semibold">Summary of Runs</h1>
+    <PageBase>
+      <h1 className="mb-6 text-2xl font-semibold">Summary of Runs</h1>
 
-          {/** Create Actual Filtering System */}
-          <div className="flex flex-col md:flex-row gap-4 mb-6">
-            <select className="px-4 py-2 border border-gray-200 rounded-md bg-white min-w-[200px] focus:outline-none focus:ring-2 focus:ring-blue-600 focus:border-transparent">
-              <option value="10/15/2024">Date: 10/15/2024</option>
-            </select>
+        {/** Create Actual Filtering System */}
+        <div className="flex flex-col md:flex-row gap-4 mb-6">
+          <select className="px-4 py-2 border border-gray-200 rounded-md bg-white min-w-[200px] focus:outline-none focus:ring-2 focus:ring-blue-600 focus:border-transparent">
+            <option value="10/15/2024">Date: 10/15/2024</option>
+          </select>
 
-            <select className="px-4 py-2 border border-gray-200 rounded-md bg-white min-w-[200px] focus:outline-none focus:ring-2 focus:ring-blue-600 focus:border-transparent">
-              <option value="all">Driver: All</option>
-            </select>
+          <select className="px-4 py-2 border border-gray-200 rounded-md bg-white min-w-[200px] focus:outline-none focus:ring-2 focus:ring-blue-600 focus:border-transparent">
+            <option value="all">Driver: All</option>
+          </select>
 
-            <select className="px-4 py-2 border border-gray-200 rounded-md bg-white min-w-[200px] focus:outline-none focus:ring-2 focus:ring-blue-600 focus:border-transparent">
-              <option value="engine">Filter by: Engine</option>
-            </select>
-          </div>
-
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 auto-rows-min">
-            {generalRuns.map((generalRun) => (
-              <GeneralRunBubble
-                key={generalRun.id}
-                runTitle={generalRun.id}
-                driver={templateDriver}
-                onClick={() => handleRunClick(generalRun.id)}
-              />
-            ))}
-          </div>
+          <select className="px-4 py-2 border border-gray-200 rounded-md bg-white min-w-[200px] focus:outline-none focus:ring-2 focus:ring-blue-600 focus:border-transparent">
+            <option value="engine">Filter by: Engine</option>
+          </select>
         </div>
-      </div>
-    </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 auto-rows-min">
+          {generalRuns.map((generalRun) => (
+            <GeneralRunBubble
+              key={generalRun.id}
+              runTitle={generalRun.id}
+              driver={templateDriver}
+              onClick={() => handleRunClick(generalRun.id)}
+            />
+          ))}
+        </div>
+    </PageBase>
   );
 };
 

--- a/driving-day-app-frontend/src/pages/upload-page/UploadFiles.tsx
+++ b/driving-day-app-frontend/src/pages/upload-page/UploadFiles.tsx
@@ -1,14 +1,13 @@
 import React, { useState, useEffect } from "react";
 import UploadComponent from "../../components/upload-components/UploadComponent";
+import PageBase from "../../components/base-component/PageBase";
 
 export default function UploadFiles({ }) {
 
     return (
-        <div className="page-content-main">
-            <div className="flex justify-center py-16">
-                <h1>Upload Data</h1>
-            </div>
+        <PageBase>
+            <h1>Upload Data</h1>
             <UploadComponent />
-        </div>
+        </PageBase>
     )
 }

--- a/driving-day-app-frontend/src/utils/ChartTypes.ts
+++ b/driving-day-app-frontend/src/utils/ChartTypes.ts
@@ -1,0 +1,5 @@
+export const CHARTS = {
+    LINE_CHART: "Line Chart",
+    SCATTER_CHART: "Scatter Chart"
+} as const;
+export type ChartCategory = typeof CHARTS[keyof typeof CHARTS]

--- a/driving-day-app-frontend/src/utils/DataTypes.ts
+++ b/driving-day-app-frontend/src/utils/DataTypes.ts
@@ -11,7 +11,7 @@ export type DataCategory = typeof CATEGORIES[keyof typeof CATEGORIES]
 // Prefixed with 'L' indicates lowest
 
 
-export interface ChartDataProps{
+export interface ReusableChartProps{
     // Frequency in terms of seconds: i.e. 1 = 1 second, 5 = every five seconds
     frequency: number,
     categoryName: string,

--- a/driving-day-app-frontend/src/utils/DataTypes.ts
+++ b/driving-day-app-frontend/src/utils/DataTypes.ts
@@ -4,7 +4,6 @@ export const CATEGORIES = {
     COOL_TEMP: "Coolant Temperature",
     ENG_OIL_PRESSURE: "Engine Oil Pressure"
 } as const;
-
 export type DataCategory = typeof CATEGORIES[keyof typeof CATEGORIES]
 
 // Prefixed with 'H' indicates highest
@@ -19,4 +18,7 @@ export interface ReusableChartProps{
     horizontalLabel: string,
     chartPoints: any[],
 }
-  
+
+
+
+


### PR DESCRIPTION
This PR aims to bring core features from the branch `59-Create-Reusable-Graph-Components` into the `main` branch. In particular, this branch includes modularized code for reusable graph components (currently only has `LineChartTemplate` and `ScatterChartTemplate`). Additionally, this branch features UI code that allows one to toggle between various categories`:

- Chart Type
- Horizontal Label
- Vertical Label

![Screenshot 2025-03-23 153048](https://github.com/user-attachments/assets/f9715b6e-a4e4-460e-8bc7-8802e8175eaa)
